### PR TITLE
Forcing magic_halt during mass-erase of kinetis devices.

### DIFF
--- a/device.rb
+++ b/device.rb
@@ -6,13 +6,13 @@ require 'log'
 module Device
   class << self
 
-    def detect(adiv5)
+    def detect(adiv5, magic_halt=false)
 
       Log(:device, 1){ "detecting device" }
 
       ret = NRF51.detect(adiv5)
       if !ret
-        ret = Kinetis.detect(adiv5)
+        ret = Kinetis.detect(adiv5, magic_halt)
       end
 
       if !ret

--- a/flash.rb
+++ b/flash.rb
@@ -5,14 +5,16 @@ require 'backend-driver'
 
 $stderr.puts "Attaching debugger..."
 adiv5 = Adiv5.new(BackendDriver.from_string(ARGV[0]))
-k = Device.detect(adiv5)
+k = nil
 
 if ARGV[1] == '--mass-erase'
+  k = Device.detect(adiv5, true) # Reset may not work properly for mass erase if chip already flashed
   $stderr.puts "done."
   $stderr.puts "Mass erasing chip..."
   k.mass_erase
   $stderr.puts "done."
 else
+  k = Device.detect(adiv5)
   $stderr.puts "done."
 
   firmware = File.read(ARGV[1], :mode => 'rb')

--- a/kinetis.rb
+++ b/kinetis.rb
@@ -514,11 +514,11 @@ class Kinetis < KinetisBase
     }
   }
 
-  def self.detect(adiv5)
+  def self.detect(adiv5, magic_halt)
     mdmap = adiv5.ap(1)
     if mdmap && mdmap.IDR.to_i == 0x001c0000
       Log(:Kinetis, 1) {"Detected Kinetis."}
-      return Kinetis.new(adiv5)
+      return Kinetis.new(adiv5, magic_halt)
     end
     return nil
   end


### PR DESCRIPTION
- If chip is already flashed, mass erase will not erase unless reset
- Also works when unlocking a secured chip (just hold down reset when calling mass erase)

Some background:
- Using a bus pirate for flashing thousands of devices in a factory
- If the device happens to be flashed with the incorrect bootloader (or flashed multiple times) the procedure changes (more instructions to give), so just forcing an erase/unlock
- If the chip is actually locked, then have the person flashing hold down the button after the first attempt

(It would be nice to actually control the reset line with the bus pirate, similar to a jlink flasher but I'm not familiar enough with ruby/bus pirate to do that right now)