### PR TITLE
stm32: do not do mass erase on *every* flash operation :)

### DIFF
--- a/stm32.rb
+++ b/stm32.rb
@@ -136,10 +136,6 @@ class STM32F4 < ARMv7
 
   def flash_op(&block)
     self.unlock_flash
-    @flash.CR.MER = true
-    if @bank2
-      @flash.CR.MER1 = true
-    end
     yield
     Log(:stm32, 4){ "waiting for flash transaction to be completed" }
     self.wait_for_flash


### PR DESCRIPTION
This is just a stupid bug while refactoring the mass erase code into the generic flash operation code - it's not supposed to initiate mass erase before every flash operation :)