### PR TITLE
fix some typos, closes #9

### DIFF
--- a/adiv5-swd.rb
+++ b/adiv5-swd.rb
@@ -54,7 +54,7 @@ class Adiv5Swd
     if !opt[:count]
       reply = @drv.transfer(req)
     else
-      req[:count] = readcount
+      req[:val] = readcount
       reply = @drv.transfer_block(req)
     end
 

--- a/nrf51.rb
+++ b/nrf51.rb
@@ -78,6 +78,12 @@ class NRF51 < ARMv7  # not actually true, it's and armv6 cortex m0 device.
         sleep 0.01
       end
 
+      self.ERASEUICR = 1
+      while !self.READY.ready
+        Log(:nrf51, 1){ "waiting for UICR erase completion" }
+        sleep 0.01
+      end
+
       self.CONFIG.WEN = :REN  # enable read
 
       if self.CONFIG.WEN != :REN

--- a/swd-bitbang.rb
+++ b/swd-bitbang.rb
@@ -80,7 +80,7 @@ class BitbangSwd
         # reads to the AP are posted, so we need to get the result in a
         # separate transfer.
         if req[:port] == :ap
-          rdbufret = transfer(dir: :read, port: :dp, addr: Adiv5Swd::RDBUFF)
+          rdbufret = transfer(op: :read, port: :dp, addr: Adiv5Swd::RDBUFF)
           ret[:ack] = rdbufret[:ack]
           data = rdbufret[:val]
         end
@@ -108,5 +108,8 @@ class BitbangSwd
 
   def hexify(str)
     str.unpack('C*').map{|e| "%02x" % e}.join(' ')
+  end
+
+  def flush!
   end
 end


### PR DESCRIPTION
I'm really not a Ruby expert, so perhaps there's a better way to fix the `flush!` issue (see second change in `swd-bitbang.rb`). But with these changes, everything works again for me with nRF51 & BusPirate.